### PR TITLE
Add SDL_mouse.h include to SDL_svga_framebuffer.c

### DIFF
--- a/src/video/svga/SDL_svga_framebuffer.c
+++ b/src/video/svga/SDL_svga_framebuffer.c
@@ -26,6 +26,7 @@
 #include <sys/movedata.h>
 #include <sys/segments.h>
 
+#include "SDL_mouse.h"
 #include "SDL_svga_video.h"
 #include "SDL_svga_framebuffer.h"
 


### PR DESCRIPTION
This fixes failing builds on GCC 14.2